### PR TITLE
Update editions.ts

### DIFF
--- a/src/editions.ts
+++ b/src/editions.ts
@@ -545,7 +545,7 @@ const EDITIONS: Edition[] = [
           { text: "New arrows" },
           { text: "Revamped Ender Dragon fight" },
           { text: "Ability to use your second hand" },
-          { text: "Removed Enchanted Golden Apples" },
+          { text: "Removed Enchanted Golden Apple crafting recipe" },
           { text: "Better Command Blocks" }
         ]
       },


### PR DESCRIPTION
1.9 removed the crafting recipe, not enchanted golden apples themselves

(I don't why it says it's adding `export default EDITIONS`. I didn't type that)