### PR TITLE
Added Tiny Takeover

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1005,20 +1005,6 @@
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "dev": true
     },
-    "node_modules/picomatch": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/postcss": {
       "version": "8.4.49",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.49.tgz",

--- a/src/lib/editions/bedrock/drops.ts
+++ b/src/lib/editions/bedrock/drops.ts
@@ -159,5 +159,28 @@ export const drops: Version[] = [
       { text: "Husks riding Camel Husks" },
       { text: "Netherite Horse Armor" }
     ]
-  }
+  },
+
+  {
+    title: "Tiny Takeover",
+    subtitle: "26.10",
+    date: "2026-03-24",
+    type: "drop",
+    icon: "/java/version_26_1.png",
+    funFact: "Did you know? This is the first version of the game to use a two-digit year in its versioning system, marking a new era for Minecraft updates.",
+    learnMore: "@Tiny_Takeover",
+    mainFeatures: [
+      { text: "Unique new models for baby animals and mobs" },
+      { text: "Name Tags are now craftable" },
+      { text: "Golden Dandelion" },
+    ],
+    minorFeatures: [
+      { text: "Armors models for baby zombies, husks and drowned" },
+      { text: "New trumpet instrument in noteblocks" },
+      { text: "New model for adult Rabbit" },
+      { text: "Librarians no longer offers name tags as a trade, now offers red candles and yellow candles for the price of three emeralds (per candle) at the Master level." },
+      { text: "Stonecutter can now directly turn stone and deepslate into their respective cobbled variants" },
+      { text: "New sound variants for Cats, Pigs, Cows and Chickens" }
+    ]
+  },
 ] as const;

--- a/src/lib/editions/bedrock/minors.ts
+++ b/src/lib/editions/bedrock/minors.ts
@@ -2249,5 +2249,83 @@ export const minors: Version[] = [
     mainFeatures: [
       { text: "Small Changes and Bug Fixes" }
     ]
-  }
+  },
+
+  {
+    subtitle: "26.11",
+    type: "minor",
+    date: "2026-03-26",
+    learnMore: "@Bedrock_Edition_26.11",
+    mainFeatures: [
+      { text: "Bug Fixes" }
+    ]
+  },
+
+  {
+    subtitle: "26.12",
+    type: "minor",
+    date: "2026-03-31",
+    learnMore: "@Bedrock_Edition_26.12",
+    mainFeatures: [
+      { text: "Bug Fixes" }
+    ]
+  },
+
+  {
+    subtitle: "26.13",
+    type: "minor",
+    date: "2026-04-07",
+    learnMore: "@Bedrock_Edition_26.13",
+    mainFeatures: [
+      { text: "Bug Fixes" }
+    ]
+  },
+
+  {
+    subtitle: "26.20",
+    type: "minor",
+    date: "2026-04-07",
+    learnMore: "@Bedrock_Edition_26.20",
+    mainFeatures: [
+      { text: "Closed captions" },
+      { text: "Parties" },
+      { text: "Realms Hub" },
+    ],
+    minorFeatures: [
+      { text: "Improved Ore UI safe-area scrolling" },
+      { text: "Single biome worlds can now generate dripstone caves" },
+      { text: "Bug Fixes" }
+    ]
+  },
+
+  {
+    subtitle: "26.21",
+    type: "minor",
+    date: "2026-05-14",
+    learnMore: "@Bedrock_Edition_26.21",
+    mainFeatures: [
+      { text: "Bug Fixes" }
+    ]
+  },
+
+  {
+    subtitle: "26.22",
+    type: "minor",
+    date: "2026-05-21",
+    learnMore: "@Bedrock_Edition_26.22",
+    mainFeatures: [
+      { text: "Bug Fixes" }
+    ]
+  },
+
+  {
+    subtitle: "26.23",
+    type: "minor",
+    date: "2026-05-21",
+    learnMore: "@Bedrock_Edition_26.23",
+    funFact: "Did you know? This update is an hotfix for Android only, and it does have the same changelog as 26.22.",
+    mainFeatures: [
+      { text: "Bug Fixes" }
+    ]
+  },
 ] as const;

--- a/src/lib/editions/bedrock/upcomings.ts
+++ b/src/lib/editions/bedrock/upcomings.ts
@@ -1,31 +1,5 @@
 import type { NaiveVersion } from "..";
 
 export const upcomings: NaiveVersion[] = [
-  {
-    subtitle: "26.0",
-    type: "minor",
-    possibleDate: "Someday February",
-    funFact: "Did you know? This is the first version of the game to use a two-digit year in its versioning system, marking a new era for Minecraft updates.",
-    learnMore: "@Bedrock_Edition_26.0",
-    mainFeatures: [
-      { text: "Small Changes and Bug Fixes" },
-      { text: "Subtitles" },
-      { text: "Experimental features for The First Drop 2026" }
-    ],
-    minorFeatures: [
-      { text: "Clicking with a Spawn Egg on an animal spawns a baby" }
-    ]
-  },
-  {
-    title: "First Drop 2026",
-    subtitle: "26.10",
-    possibleDate: "Presumed Early 2026",
-    type: "drop",
-    icon: "/bedrock/version_26_1.png",
-    learnMore: "@First_Drop_2026",
-    mainFeatures: [
-      { text: "Unique new models for baby animals" },
-      { text: "Name Tags are now craftable" },
-    ]
-  }
+
 ] as const;

--- a/src/lib/editions/java/drops.ts
+++ b/src/lib/editions/java/drops.ts
@@ -166,4 +166,27 @@ export const drops: Version[] = [
       { text: "Netherite Horse Armor" }
     ]
   },
+
+  {
+    title: "Tiny Takeover",
+    subtitle: "26.1",
+    date: "2026-04-26",
+    type: "drop",
+    icon: "/java/version_26_1.png",
+    funFact: "Did you know? This is the first version of the game to use a two-digit year in its versioning system, marking a new era for Minecraft updates.",
+    learnMore: "@Tiny_Takeover",
+    mainFeatures: [
+      { text: "Unique new models for baby animals and mobs" },
+      { text: "Name Tags are now craftable" },
+      { text: "Golden Dandelion" },
+    ],
+    minorFeatures: [
+      { text: "Armors models for baby zombies, husks and drowned" },
+      { text: "New trumpet instrument in noteblocks" },
+      { text: "New model for adult Rabbit" },
+      { text: "Librarians no longer offers name tags as a trade, now offers red candles and yellow candles for the price of three emeralds (per candle) at the Master level." },
+      { text: "Stonecutter can now directly turn stone and deepslate into their respective cobbled variants" },
+      { text: "New sound variants for Cats, Pigs, Cows and Chickens" }
+    ]
+  },
 ] as const;

--- a/src/lib/editions/java/drops.ts
+++ b/src/lib/editions/java/drops.ts
@@ -170,7 +170,7 @@ export const drops: Version[] = [
   {
     title: "Tiny Takeover",
     subtitle: "26.1",
-    date: "2026-04-26",
+    date: "2026-03-24",
     type: "drop",
     icon: "/java/version_26_1.png",
     funFact: "Did you know? This is the first version of the game to use a two-digit year in its versioning system, marking a new era for Minecraft updates.",

--- a/src/lib/editions/java/minors.ts
+++ b/src/lib/editions/java/minors.ts
@@ -1191,5 +1191,25 @@ export const minors: Version[] = [
     mainFeatures: [
       { text: "Small Changes and Bug Fixes" }
     ]
+  },
+
+  {
+    subtitle: "26.1.1",
+    type: "minor",
+    date: "2026-05-01",
+    learnMore: "@Java_Edition_26.1.1",
+    mainFeatures: [
+      { text: "Bug Fixes" }
+    ]
+  },
+
+  {
+    subtitle: "26.1.2",
+    type: "minor",
+    date: "2026-05-09",
+    learnMore: "@Java_Edition_26.1.2",
+    mainFeatures: [
+      { text: "Small Changes and Bug Fixes" }
+    ]
   }
 ] as const;

--- a/src/lib/editions/java/upcomings.ts
+++ b/src/lib/editions/java/upcomings.ts
@@ -2,19 +2,6 @@ import type { NaiveVersion } from "..";
 
 export const upcomings: NaiveVersion[] = [
   {
-    title: "First Drop 2026",
-    subtitle: "26.1",
-    possibleDate: "Presumed Early 2026",
-    type: "drop",
-    icon: "/java/version_26_1.png",
-    funFact: "Did you know? This is the first version of the game to use a two-digit year in its versioning system, marking a new era for Minecraft updates.",
-    learnMore: "@First_Drop_2026",
-    mainFeatures: [
-      { text: "Unique new models for baby animals" },
-      { text: "Name Tags are now craftable" },
-    ]
-  },
-  {
     title: "Vibrant Visuals",
     type: "minor",
     possibleDate: "Future",


### PR DESCRIPTION
Introduce the Tiny Takeover update for Java and Bedrock editions, including new features and bug fixes. Adjusted release dates for better accuracy.